### PR TITLE
Python 2/3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,48 +6,10 @@ python file system database
 [![Latest Version](https://pypip.in/version/Fsdb/badge.svg?style=flat)](https://pypi.python.org/pypi/Fsdb/)
 [![Documentation Status](https://readthedocs.org/projects/pyfsdb/badge/?version=latest)](https://pyfsdb.readthedocs.org/en/latest)
 
-One class solution to expose a simple api (add,get,remove) to menage the saving of files on disk.  
-Files are placed under specified fsdb root folder and are managed using a directory tree generated from the file digest
+Fsdb is the right library for every one that doesn't want to store big files on his database.  
+Fsdb will works alongside your favorite database, it will help you to easily store and manage files while your database will handle metadata managment.  
+Fsdb is designed to work with a huge number of big files, it will use your filesystem in a smart way.
 
-#####Installation
-Fsdb is available on PyPI so you can easily install through pip  
-`pip install Fsdb`
-
-#####Usage
-```python
-from fsdb import Fsdb
-
-#create new fsdb instance
-myFsdb = Fsdb("/tmp/fsdbRoot")
-
-#add file
-fileDigest = myFsdb.add("/path/to/an/existing/file")
-
-#control if file exists
-myFsdb.exists(fileDigest)
-
-#get file path
-myFsdb.get_file_path(fileDigest)
-
-#remove file
-myFsdb.remove(fileDigest)
-```
-
-#####Path example
-If you add a file with the following sha1sum to an fsdb instance with a configured deep level of 3
-`7bf770901365d4b12ce46a2d545407daf224e583`  
-The file will be placed in  
-`/path_To_Fsdb_Root/7b/f770/901365d4/b12ce46a2d545407daf224e583`
-
-#####Configuration
-There are two ways to configure fsbd:
- - passing arguments to class constructor
- - editing the json config file
- 
-The config file must be in the fsdb root folder with name ```.fsdb.conf``` and must be written in a valid json syntax
-
-| config name | type | default value | description |
-|-------------|------|---------------|-------------|
-|mode | string | "0770" | permissions mask to use in file/folder creation |
-|deep | int | 3 | number of levels to use for directory tree |
-|hash_alg | string | "sha1" | name of the hash algorithm to use for file digest|
+#####Documentation
+You can find fsdb documentation on:  
+[pyFsdb.readthedocs.org](http://pyfsdb.readthedocs.org/en/latest/)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,11 @@
 
 Fsdb documentation
 ===================
-Fsdb is a one class solution to expose a simple api (add,get,remove) to menage the saving of files on disk.  
-Files are placed under specified fsdb root folder and are managed using a directory tree generated from the file digest.
+Fsdb is the right library for every one that doesn't want to store big files on his database.
+
+Fsdb will works alongside your favorite database, it will help you to easily store and manage files while your database will handle metadata managment.
+
+Fsdb is designed to work with a huge number of big files, it will use your filesystem in a smart way.
 
 Quick start
 -----------
@@ -27,16 +30,47 @@ Usage
     myFsdb = Fsdb("/tmp/fsdbRoot")
 
     #add file
-    fileDigest = myFsdb.add("/path/to/an/existing/file")
+    file_digest = myFsdb.add("/path/to/an/existing/file")
 
     #control if file exists
-    myFsdb.exists(fileDigest)
+    if file_digest in myFsdb:
+        # file exists
 
     #get file path
-    myFsdb.get_file_path(fileDigest)
+    myFsdb[file_digest]
+
+    #check file integrity
+    myFsdb.check(file_digest)
 
     #remove file
-    myFsdb.remove(fileDigest)
+    myFsdb.remove(file_digest)
+
+Configuration
+-------------
+
+There are two ways to configure fsbd:
+ - passing arguments to class constructor :py:func:`Fsdb.__init__()`
+ - editing the json config file
+ 
+The config file must be in the fsdb root folder with name ```.fsdb.conf``` and must be written in a valid json syntax
+
+=============  ========  ==============  ===================================================
+config name    type      default value   description 
+=============  ========  ==============  ===================================================
+mode           string    "0770"          permissions mask to use in file/folder creation
+deep           int       3               number of levels to use for directory tree
+hash_alg       string    "sha1"          name of the hash algorithm to use for file digest
+=============  ========  ==============  ===================================================
+
+Path example
+------------
+If you add a file with the following sha1sum to an fsdb instance with a configured deep level of 3
+
+    ``7bf770901365d4b12ce46a2d545407daf224e583``
+
+The file will be placed in
+
+    ``/path_To_Fsdb_Root/7b/f770/901365d4/b12ce46a2d545407daf224e583``
 
 
 Contents

--- a/fsdb/__init__.py
+++ b/fsdb/__init__.py
@@ -1,1 +1,7 @@
-from fsdb import Fsdb
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from .fsdb import Fsdb

--- a/fsdb/config.py
+++ b/fsdb/config.py
@@ -1,3 +1,13 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from builtins import int
+from builtins import oct
+from builtins import str, bytes
+from future import standard_library
+standard_library.install_aliases()
 import json
 
 CONFIG_SECTION = "fsdb"
@@ -18,7 +28,7 @@ def normalizeConf(oldConf):
 
     if 'mode' not in conf:
         conf['mode'] = DEFAULT_MODE
-    elif not isinstance(conf['mode'], basestring):
+    elif not isinstance(conf['mode'], str):
         raise TypeError(TAG+": `mode` must be a string")
 
     conf['mode'] = int(conf['mode'], 8)
@@ -32,7 +42,7 @@ def normalizeConf(oldConf):
 
     if 'hash_alg' not in conf:
         conf['hash_alg'] = DEFAULT_HASH_ALG
-    elif not isinstance(conf['hash_alg'], basestring):
+    elif not isinstance(conf['hash_alg'], str):
         raise TypeError(TAG+": `hash_alg` must be a string")
     elif conf['hash_alg'] not in ACCEPTED_HASH_ALG:
         raise ValueError(TAG+": `hash_alg` must be one of "+str(ACCEPTED_HASH_ALG))
@@ -41,8 +51,10 @@ def normalizeConf(oldConf):
 
 
 def loadConf(configPath):
-    with open(configPath, 'r') as configFile:
-        conf = json.load(configFile)
+    print(configPath)
+    with open(configPath, 'r', encoding='utf-8') as configFile:
+        content = configFile.read()
+        conf = json.loads(content)
 
     return normalizeConf(conf)
 
@@ -56,8 +68,11 @@ def writeConf(configPath, conf):
     if 'mode' in mConf:
         mConf['mode'] = str(oct(mConf['mode']))
 
-    with open(configPath, 'w') as outfile:
-        json.dump(mConf, outfile, indent=4)
+    json_content = json.dumps(mConf, indent=4)
+    if isinstance(json_content, bytes):
+        json_content = json_content.decode('utf-8')
+    with open(configPath, 'w', encoding='utf-8') as outfile:
+        outfile.write(json_content)
 
 
 def getDefaultConf():

--- a/fsdb/fsdb.py
+++ b/fsdb/fsdb.py
@@ -126,7 +126,7 @@ class Fsdb(object):
         if not os.path.isfile(filePath):
             raise Exception("fsdb can not add: not regular file received")
 
-        digest = Fsdb.file_digest(filePath, algorithm=self._conf['hash_alg'])
+        digest = self._calc_digest(filePath)
 
         if self.exists(digest):
             self.logger.debug('Added File: ['+digest+'] ( Already exists. Skipping transfer)')
@@ -195,7 +195,11 @@ class Fsdb(object):
           Returns:
             True if the file is not corrupted
         """
-        return self._calc_digest(self.get_file_path(digest)) == digest
+        path = self.get_file_path(digest)
+        if self._calc_digest(path) != digest:
+            self.logger.warning("found corrupted file: '{}'".format(path))
+            return False
+        return True
 
     def corrupted(self):
         """Iterate over digests of all corrupted stored files"""

--- a/fsdb/fsdb.py
+++ b/fsdb/fsdb.py
@@ -238,6 +238,14 @@ class Fsdb(object):
     def __contains__(self, digest):
         return self.exists(digest)
 
+    def __getitem__(self, digest):
+        """return the file path of the stored file with the given digest"""
+        if not isinstance(digest, basestring):
+            raise TypeError("key must be instance of basestring")
+        if not self.exists(digest):
+            raise KeyError("no stored file found for '{}'".format(digest))
+        return self.get_file_path(digest)
+
     @staticmethod
     def file_digest(filepath, algorithm="sha1", block_size=2**20):
         """Calculate digest of the file located at @filepath

--- a/fsdb/fsdb.py
+++ b/fsdb/fsdb.py
@@ -173,6 +173,7 @@ class Fsdb(object):
 
     def exists(self, digest):
         """Check file existence in fsdb
+
           Returns:
             True if file exists under this instance of fsdb, false otherwise
         """
@@ -180,6 +181,7 @@ class Fsdb(object):
 
     def get_file_path(self, digest):
         """Retrieve the absolute path to the file with the given digest
+
           Args:
             digest -- digest of the file
           Returns:
@@ -190,6 +192,7 @@ class Fsdb(object):
 
     def check(self, digest):
         """Check the integrity of the file with the given digest
+
           Args:
             digest -- digest of the file to check
           Returns:
@@ -249,6 +252,7 @@ class Fsdb(object):
     @staticmethod
     def file_digest(filepath, algorithm="sha1", block_size=2**20):
         """Calculate digest of the file located at @filepath
+
          Args:
             digest -- digest of the file to remove
         """
@@ -277,6 +281,7 @@ class Fsdb(object):
     def generate_tree_path(fileDigest, deep):
         """Generate a relative path from the given fileDigest
             relative path has a numbers of directories levels according to @deep
+
          Args:
             fileDigest -- digest for which the relative path will be generate
             deep -- number of levels to use in relative path generation

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     url = "https://github.com/ael-code/pyFsdb",
     license = "LGPLv3",
     test_suite='tests',
+    install_requires=[
+        'future'
+    ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,7 @@
-import fsdb_test
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from . import fsdb_test

--- a/tests/fsdb_test.py
+++ b/tests/fsdb_test.py
@@ -122,6 +122,24 @@ class FsdbTestFunction(unittest.TestCase):
         digest = self.fsdb.add(self.createTestFile())
         self.assertIn(digest, self.fsdb)
 
+    def test_get_item(self):
+        fpath = self.createTestFile()
+        digest = self.fsdb.add(fpath)
+        self.assertTrue(filecmp.cmp(fpath, self.fsdb[digest], shallow=False))
+
+    def test_get_item_type_error(self):
+        with self.assertRaises(TypeError):
+            self.fsdb[3]
+        with self.assertRaises(TypeError):
+            self.fsdb[list()]
+
+    def test_get_item_key_error(self):
+        fpath = self.createTestFile()
+        digest = self.fsdb._calc_digest(fpath)
+        with self.assertRaises(KeyError):
+            self.fsdb[digest]
+
+
 class FsdbTestConfig(unittest.TestCase):
 
     def setUp(self):

--- a/tests/fsdb_test.py
+++ b/tests/fsdb_test.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open, range, str
+from future import standard_library
+standard_library.install_aliases()
 import unittest
 import os
 import random
@@ -11,11 +18,11 @@ import tempfile
 from fsdb import Fsdb
 
 class FsdbTestFunction(unittest.TestCase):
-    
+
     def setUp(self):
         self.fsdb_tmp_path = tempfile.mkdtemp(prefix="fsdb_test")
         self.fsdb = Fsdb(os.path.join(self.fsdb_tmp_path, "fsdbRoot"))
-    
+
     def tearDown(self):
         shutil.rmtree(self.fsdb_tmp_path)
 
@@ -41,7 +48,7 @@ class FsdbTestFunction(unittest.TestCase):
     def test_get_file_path(self):
         testFilePath = self.createTestFile()
         digest = self.fsdb.add(testFilePath)
-        self.assertIsInstance(self.fsdb.get_file_path(digest),basestring)
+        self.assertIsInstance(self.fsdb.get_file_path(digest), str)
         self.assertTrue(os.path.isabs(self.fsdb.get_file_path(digest)))
 
     def test_same_file_after_retrieval(self):
@@ -49,12 +56,12 @@ class FsdbTestFunction(unittest.TestCase):
         digest = self.fsdb.add(testFilePath)
         storedFilePath = self.fsdb.get_file_path(digest)
         self.assertTrue( filecmp.cmp(testFilePath, storedFilePath, shallow=False) )
-        
+
     def test_remove_existing_file(self):
         testFilePath = self.createTestFile()
         digest = self.fsdb.add(testFilePath)
         self.fsdb.remove(digest)
-        
+
     def test_remove_not_existing_file(self):
         with self.assertRaisesRegexp(OSError,"No such file or directory"):
             self.fsdb.remove(randomID(20))
@@ -110,7 +117,7 @@ class FsdbTestFunction(unittest.TestCase):
         for _ in range(num):
             self.fsdb.add(self.createTestFile())
         self.assertEqual(len(self.fsdb), num)
-    
+
     def test_len_empty(self):
         self.assertEqual(len(self.fsdb), 0)
 


### PR DESCRIPTION
This pull request make the code compatible with both python2 and python3. To make a easy transition, I used the `future` library, which provides wrappers for python3 features into python2.

**NOTE**: I am _not_ proposing to officially support python3 from tomorrow, which would require some more consideration. But making a single codebase future-proof is an important goal, I believe.
### How to test
#### Python2

``` sh
mkvirtualenv -p /usr/bin/python2 fsdb-2
python setup.py 'test'
```
#### Python3

``` sh
mkvirtualenv -p /usr/bin/python3 fsdb-3
python setup.py 'test'
```
